### PR TITLE
Session3 StatefulWidget のライフサイクル

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "files.watcherExclude": {
     "**/.fvm": true
   },
+  "editor.formatOnSave": true,
   "cSpell.ignoreWords": ["yumemi"]
 }

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -17,8 +17,9 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
   }
 
   Future<void> _navigateAfterLayout() async {
-    await WidgetsBinding.instance.endOfFrame;
-    await _navigate();
+    await WidgetsBinding.instance.endOfFrame.then((_) {
+      _navigate();
+    });
   }
 
   Future<void> _navigate() async {

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_training/weather_screen.dart';
 
 class GreenBackScreen extends StatefulWidget {
   const GreenBackScreen({super.key});
@@ -8,6 +10,32 @@ class GreenBackScreen extends StatefulWidget {
 }
 
 class _GreenBackScreenState extends State<GreenBackScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(navigate());
+  }
+
+  Future<void> navigate() async {
+    await WidgetsBinding.instance.endOfFrame.then((_) {
+      if (mounted) {
+        // 0.5秒後遅延実行
+        Future.delayed(
+          const Duration(milliseconds: 500),
+          () => {
+            Navigator.push(
+              context,
+              MaterialPageRoute<WeatherScreen>(
+                builder: (context) => const WeatherScreen(),
+              ),
+            ),
+          },
+        );
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class GreenBackScreen extends StatefulWidget {
+  const GreenBackScreen({super.key});
+
+  @override
+  State<GreenBackScreen> createState() => _GreenBackScreenState();
+}
+
+class _GreenBackScreenState extends State<GreenBackScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(color: Colors.green,),
+    );
+  }
+}

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -13,11 +13,15 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
   @override
   void initState() {
     super.initState();
-    unawaited(navigate());
+    unawaited(_navigateAfterLayout());
   }
 
-  Future<void> navigate() async {
+  Future<void> _navigateAfterLayout() async {
     await WidgetsBinding.instance.endOfFrame;
+    await _navigate();
+  }
+
+  Future<void> _navigate() async {
     await Future.delayed(const Duration(milliseconds: 500), () {});
     if (mounted) {
       await Navigator.push(
@@ -26,7 +30,7 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
           builder: (context) => const WeatherScreen(),
         ),
       );
-      await navigate();
+      await _navigate();
     }
   }
 

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -24,18 +24,21 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
         () => {
           if (mounted)
             {
-              Navigator.push(
-                context,
-                MaterialPageRoute<WeatherScreen>(
-                  builder: (context) => const WeatherScreen(),
-                ),
-              ).then((value) {
-                navigate();
-              }),
+              _navigate(),
             },
         },
       );
     });
+  }
+
+  Future<void> _navigate() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute<WeatherScreen>(
+        builder: (context) => const WeatherScreen(),
+      ),
+    );
+    await navigate();
   }
 
   @override

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -10,7 +10,6 @@ class GreenBackScreen extends StatefulWidget {
 }
 
 class _GreenBackScreenState extends State<GreenBackScreen> {
-
   @override
   void initState() {
     super.initState();
@@ -19,27 +18,30 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
 
   Future<void> navigate() async {
     await WidgetsBinding.instance.endOfFrame.then((_) {
-      if (mounted) {
-        // 0.5秒後遅延実行
-        Future.delayed(
-          const Duration(milliseconds: 500),
-          () => {
-            Navigator.push(
-              context,
-              MaterialPageRoute<WeatherScreen>(
-                builder: (context) => const WeatherScreen(),
+      // 0.5秒後遅延実行
+      Future.delayed(
+        const Duration(milliseconds: 500),
+        () => {
+          if (mounted)
+            {
+              Navigator.push(
+                context,
+                MaterialPageRoute<WeatherScreen>(
+                  builder: (context) => const WeatherScreen(),
+                ),
               ),
-            ),
-          },
-        );
-      }
+            }
+        },
+      );
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Container(color: Colors.green,),
+      body: Container(
+        color: Colors.green,
+      ),
     );
   }
 }

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -29,8 +29,10 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
                 MaterialPageRoute<WeatherScreen>(
                   builder: (context) => const WeatherScreen(),
                 ),
-              ),
-            }
+              ).then((value) {
+                navigate();
+              }),
+            },
         },
       );
     });

--- a/lib/green_back_screen.dart
+++ b/lib/green_back_screen.dart
@@ -17,28 +17,17 @@ class _GreenBackScreenState extends State<GreenBackScreen> {
   }
 
   Future<void> navigate() async {
-    await WidgetsBinding.instance.endOfFrame.then((_) {
-      // 0.5秒後遅延実行
-      Future.delayed(
-        const Duration(milliseconds: 500),
-        () => {
-          if (mounted)
-            {
-              _navigate(),
-            },
-        },
+    await WidgetsBinding.instance.endOfFrame;
+    await Future.delayed(const Duration(milliseconds: 500), () {});
+    if (mounted) {
+      await Navigator.push(
+        context,
+        MaterialPageRoute<WeatherScreen>(
+          builder: (context) => const WeatherScreen(),
+        ),
       );
-    });
-  }
-
-  Future<void> _navigate() async {
-    await Navigator.push(
-      context,
-      MaterialPageRoute<WeatherScreen>(
-        builder: (context) => const WeatherScreen(),
-      ),
-    );
-    await navigate();
+      await navigate();
+    }
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/weather_screen.dart';
+import 'package:flutter_training/green_back_screen.dart';
 
 void main() {
   runApp(const MainApp());
@@ -11,7 +11,7 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: WeatherScreen(),
+      home: GreenBackScreen(),
     );
   }
 }

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -74,7 +74,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
                         children: [
                           Expanded(
                             child: TextButton(
-                              onPressed: () { },
+                              onPressed: () { Navigator.pop(context); },
                               child: Text(
                                 'Close',
                                 style: textStyle?.copyWith(color: Colors.blue),


### PR DESCRIPTION
## 課題
StatefulWidget のライフサイクル
close #4

## 対応箇所

- [x] 緑色の画面を作成
- [x] 起動画面を前回まで作っていた画面から緑色画面に変更
- [x] 緑色の画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## レビューポイント

- [x] build メソッド直下で画面遷移処理を書いていないか
- [x] sleep を使っていないか
- [x] mounted のチェックをしているか
- [x] 初期画面と天気画面の Widget を分割しているか
- [x] iOS・Android のスワイプバックを考慮しているか

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| iOS |
|----------|
| <video src="https://github.com/user-attachments/assets/d3dc0fea-3a42-4a4b-8b00-a0be5a9984f7"> |

| android |  |
|:-:|:-:|
| スワイプバック | <img width="320" alt="ファイル名" src="https://github.com/user-attachments/assets/91b8b3c8-36db-46ef-baa4-eccbf852d450"> |
| クローズボタン | <img width="320" alt="ファイル名" src="https://github.com/user-attachments/assets/5b3db27b-1a6b-4402-a9e6-fc0615d2f4cf"> |

