### PR TITLE
Session5 API のエラーハンドリング

### DIFF
--- a/lib/app_alert_dialog.dart
+++ b/lib/app_alert_dialog.dart
@@ -8,6 +8,10 @@ class AppAlertDialog extends StatelessWidget {
 
   final Exception _exception;
 
+  void _close(BuildContext context) {
+    Navigator.pop(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -15,7 +19,7 @@ class AppAlertDialog extends StatelessWidget {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0)),
       actions: <Widget>[
         TextButton(
-          onPressed: () => Navigator.pop(context),
+          onPressed: () => _close(context),
           child: const Text('OK'),
         ),
       ],

--- a/lib/app_alert_dialog.dart
+++ b/lib/app_alert_dialog.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class AppAlertDialog extends StatelessWidget {
+  const AppAlertDialog({
+    required Exception exception,
+    super.key,
+  }) : _exception = exception;
+
+  final Exception _exception;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Text(_exception.toString()),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0)),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/weather_model.dart
+++ b/lib/weather_model.dart
@@ -14,7 +14,7 @@ class WeatherModel {
   final YumemiWeather _client;
 
   WeatherType fetchCondition() {
-    final response = _client.fetchSimpleWeather();
+    final response = _client.fetchThrowsWeather('tokyo');
     return WeatherType.values.firstWhere(
       (element) => element.name == response,
       orElse: () => WeatherType.none,

--- a/lib/weather_model.dart
+++ b/lib/weather_model.dart
@@ -7,6 +7,20 @@ enum WeatherType {
   rainy,
 }
 
+// YumemiWeatherError.invalidParameter
+class WeatherInvalidParameterException implements Exception {
+  final String _message = 'WeatherInvalidParameterException';
+  @override
+  String toString() => _message;
+}
+
+// YumemiWeatherError.unknown
+class WeatherUnknownException implements Exception {
+  final String _message = 'WeatherUnknownException';
+  @override
+  String toString() => _message;
+}
+
 class WeatherModel {
   // コンストラクタ
   WeatherModel(this._client);
@@ -14,10 +28,18 @@ class WeatherModel {
   final YumemiWeather _client;
 
   WeatherType fetchCondition() {
-    final response = _client.fetchThrowsWeather('tokyo');
-    return WeatherType.values.firstWhere(
-      (element) => element.name == response,
-      orElse: () => WeatherType.none,
-    );
+    try {
+      final response = _client.fetchThrowsWeather('tokyo');
+      return WeatherType.values.firstWhere(
+        (element) => element.name == response,
+        orElse: () => WeatherType.none,
+      );
+    } on YumemiWeatherError catch (e) {
+      throw switch (e) {
+        YumemiWeatherError.invalidParameter =>
+          WeatherInvalidParameterException(),
+        YumemiWeatherError.unknown => WeatherUnknownException(),
+      };
+    }
   }
 }

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -21,12 +21,12 @@ class _WeatherScreenState extends State<WeatherScreen> {
       try {
         _weatherType = _model.fetchCondition();
       } on Exception catch (e) {
-        _showMyDialog(context, e);
+        _showAlertDialog(context, e);
       }
     });
   }
 
-  Future<void> _showMyDialog(BuildContext context, Exception e) {
+  Future<void> _showAlertDialog(BuildContext context, Exception e) {
     return showDialog<void>(
       context: context,
       builder: (context) {

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_training/app_alert_dialog.dart';
@@ -16,19 +18,20 @@ class _WeatherScreenState extends State<WeatherScreen> {
   final WeatherModel _model = WeatherModel(YumemiWeather());
   WeatherType _weatherType = WeatherType.none;
 
-  Future<void> updateWeatherType(BuildContext context) async {
+  void updateWeatherType(BuildContext context) {
     setState(() {
       try {
         _weatherType = _model.fetchCondition();
       } on Exception catch (e) {
-        _showAlertDialog(context, e);
+        unawaited(_showAlertDialog(context, e));
       }
     });
   }
 
-  Future<void> _showAlertDialog(BuildContext context, Exception e) {
-    return showDialog<void>(
+  Future<void> _showAlertDialog(BuildContext context, Exception e) async {
+    await showDialog<void>(
       context: context,
+      barrierDismissible: false,
       builder: (context) {
         return AppAlertDialog(exception: e);
       },
@@ -99,8 +102,8 @@ class _WeatherScreenState extends State<WeatherScreen> {
                         ),
                         Expanded(
                           child: TextButton(
-                            onPressed: () async {
-                              await updateWeatherType(context);
+                            onPressed: () {
+                              updateWeatherType(context);
                             },
                             child: Text(
                               'Reload',

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -99,7 +99,9 @@ class _WeatherScreenState extends State<WeatherScreen> {
                         ),
                         Expanded(
                           child: TextButton(
-                            onPressed: () => {updateWeatherType(context)},
+                            onPressed: () async {
+                              await updateWeatherType(context);
+                            },
                             child: Text(
                               'Reload',
                               style: textStyle?.copyWith(color: Colors.blue),

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_training/app_alert_dialog.dart';
 import 'package:flutter_training/gen/assets.gen.dart';
 import 'package:flutter_training/weather_model.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
@@ -15,10 +16,23 @@ class _WeatherScreenState extends State<WeatherScreen> {
   final WeatherModel _model = WeatherModel(YumemiWeather());
   WeatherType _weatherType = WeatherType.none;
 
-  void updateWeatherType() {
+  Future<void> updateWeatherType(BuildContext context) async {
     setState(() {
-      _weatherType = _model.fetchCondition();
+      try {
+        _weatherType = _model.fetchCondition();
+      } on Exception catch (e) {
+        _showMyDialog(context, e);
+      }
     });
+  }
+
+  Future<void> _showMyDialog(BuildContext context, Exception e) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AppAlertDialog(exception: e);
+      },
+    );
   }
 
   @override
@@ -26,79 +40,81 @@ class _WeatherScreenState extends State<WeatherScreen> {
     final textStyle = Theme.of(context).textTheme.labelLarge;
 
     return Scaffold(
-        body: Center(
-          child: FractionallySizedBox(
-            widthFactor: 0.5,
-            child: Column(
-              children: [
-                const Spacer(),
-                Column(
-                  children: [
-                    AspectRatio(
-                      aspectRatio: 1,
-                      child: _WeatherImage(weatherType: _weatherType),
-                    ),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
+      body: Center(
+        child: FractionallySizedBox(
+          widthFactor: 0.5,
+          child: Column(
+            children: [
+              const Spacer(),
+              Column(
+                children: [
+                  AspectRatio(
+                    aspectRatio: 1,
+                    child: _WeatherImage(weatherType: _weatherType),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          child: Text(
+                            '** ℃',
+                            style: textStyle?.copyWith(color: Colors.blue),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          child: Text(
+                            '** ℃',
+                            style: textStyle?.copyWith(color: Colors.red),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              Expanded(
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 80),
+                    child: Row(
                       children: [
                         Expanded(
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 16),
+                          child: TextButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
                             child: Text(
-                              '** ℃',
+                              'Close',
                               style: textStyle?.copyWith(color: Colors.blue),
-                              textAlign: TextAlign.center,
                             ),
                           ),
                         ),
                         Expanded(
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 16),
+                          child: TextButton(
+                            onPressed: () => {updateWeatherType(context)},
                             child: Text(
-                              '** ℃',
-                              style: textStyle?.copyWith(color: Colors.red),
-                              textAlign: TextAlign.center,
+                              'Reload',
+                              style: textStyle?.copyWith(color: Colors.blue),
                             ),
                           ),
                         ),
                       ],
                     ),
-                  ],
-                ),
-                Expanded(
-                  child: Align(
-                    alignment: Alignment.topCenter,
-                    child: Padding(
-                      padding: const EdgeInsets.only(top: 80),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: TextButton(
-                              onPressed: () { Navigator.pop(context); },
-                              child: Text(
-                                'Close',
-                                style: textStyle?.copyWith(color: Colors.blue),
-                              ),
-                            ),
-                          ),
-                          Expanded(
-                            child: TextButton(
-                              onPressed: () => { updateWeatherType() },
-                              child: Text(
-                                'Reload',
-                                style: textStyle?.copyWith(color: Colors.blue),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 課題
Session5 API のエラーハンドリング
close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる

### レビュー観点
- エラーの内容によって、メッセージを分けているか
- クリックイベントをメソッドとして切り出しているか
- Dialog をコンポーネントとして抽出しているか
- エラーハンドリングが公式ドキュメントに従っているか

## 動作


| expected | actual |
|----------|--------|
| <img width="320" alt="ファイル名" src="https://raw.githubusercontent.com/yumemi-inc/flutter-training-template/main/docs/sessions/images/error/demo.gif"> | <img width="320" alt="ファイル名" src="https://github.com/user-attachments/assets/dc589544-20eb-47db-a909-296bded2be08"> |
